### PR TITLE
Reduce JS footprint

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,14 @@ import {
   formatHex,
   formatRgb,
   inGamut,
+  modeOklch,
+  modeP3,
   parse,
-} from "culori";
+  useMode,
+} from "culori/fn";
+
+useMode(modeP3);
+useMode(modeOklch);
 
 // API
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "size-limit": [
     {
-      "limit": "30 kB"
+      "limit": "15 kB"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
`culori` has all color functions build-in. With `culori/fn` you specify what color functions do you need to support.

Size goes from 19 KB → 11 KB.